### PR TITLE
Bug fix

### DIFF
--- a/Plugin.XF.Controls/iOS/Renderer/EnhancedWebViewRenderer.cs
+++ b/Plugin.XF.Controls/iOS/Renderer/EnhancedWebViewRenderer.cs
@@ -60,10 +60,12 @@ namespace Plugin.XF.Controls.iOS.Renderer
 
                 UrlWebViewSource source = (Xamarin.Forms.UrlWebViewSource)Element.Source;
                 var webRequest = new NSMutableUrlRequest(new NSUrl(source.Url));
-                if (Element.CustomHeaders.Count > 0)
-                {
-                    foreach (string key in Element.CustomHeaders.Keys)
-                        webRequest[key] = Element.CustomHeaders[key];
+                if (Element.CustomHeaders != null) {
+                    if (Element.CustomHeaders.Count > 0)
+                    {
+                        foreach (string key in Element.CustomHeaders.Keys)
+                            webRequest[key] = Element.CustomHeaders[key];
+                    }
                 }
                 if (!string.IsNullOrEmpty(Element.Username) && !string.IsNullOrEmpty(Element.Password))
                 {


### PR DESCRIPTION
If no custom headers are added to the webview, Element.CustomHeaders is null, this will cause a crash on iOS.   Added case for no custom headers to prevent NullReferenceException.